### PR TITLE
Handle unescaped slashes

### DIFF
--- a/spec/MessageValidator/FakeHttpsMessageValidatorSpec.php
+++ b/spec/MessageValidator/FakeHttpsMessageValidatorSpec.php
@@ -33,14 +33,14 @@ final class FakeHttpsMessageValidatorSpec extends ObjectBehavior
         $request = new Response(
             200,
             ['Content-Type' => 'application/json'],
-            json_encode(['foo' => 'http://www.example.com/'])
+            json_encode(['foo' => 'http://www.example.com/', 'bar' => 'baz http://www.example.com/'])
         );
 
         $this->messageValidator->validate(Argument::that(function (MessageInterface $message) {
             return str($message) === str(new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                json_encode(['foo' => 'https://www.example.com/'])
+                json_encode(['foo' => 'https://www.example.com/', 'bar' => 'baz http://www.example.com/'])
             ));
         }))->shouldBeCalled();
 

--- a/src/MessageValidator/FakeHttpsMessageValidator.php
+++ b/src/MessageValidator/FakeHttpsMessageValidator.php
@@ -28,7 +28,7 @@ final class FakeHttpsMessageValidator implements MessageValidator
     {
         try {
             $this->jsonDecoder->decode($message->getBody());
-            $message = $message->withBody(stream_for(str_replace('http:\/\/', 'https:\/\/', $message->getBody())));
+            $message = $message->withBody(stream_for(str_replace('"http:', '"https:', $message->getBody())));
         } catch (Exception $e) {
             // Do nothing.
         }


### PR DESCRIPTION
JSON may or may not have escaped slashes. This changes the rewrite to ignore the slashes, and instead check that the URI appears at the beginning of a property value (and so means that URIs that appear in the middle of the text aren't changed).